### PR TITLE
Add additional MIBs to unifi-security-gateway.yml

### DIFF
--- a/profiles/snmp-profiles/ubiquiti/unifi-security-gateway.yml
+++ b/profiles/snmp-profiles/ubiquiti/unifi-security-gateway.yml
@@ -1,10 +1,15 @@
 ---
-extends: 
+extends:
   - if-mib.yml
   - system-mib.yml
   - ucd-mib.yml
+  - host-resources-mib.yml
+  - ip-mib.yml
+  - ospf-mib.yml
+  - tcp-mib.yml
+  - udp-mib.yml
 
 provider: kentik-firewall
 
 sysobjectid:
-  - 1.3.6.1.4.1.41112.1.5  # Ubiquiti EdgeMax
+  - 1.3.6.1.4.1.41112.1.5 # Ubiquiti EdgeMax


### PR DESCRIPTION
Added a few MIBs that my Ubiquiti EdgeRouterX supports when it uses the unifi-security-gateway.yml profile.